### PR TITLE
deal with long name searches

### DIFF
--- a/indexer.go
+++ b/indexer.go
@@ -375,7 +375,15 @@ const indexSettings = `
                         "lowercase",
                         "prefix_filter" 
                     ]
-                }			
+				},
+				"name_search": {
+					"type": "custom",
+					"tokenizer": "standard",
+					"filter": [
+						"lowercase",
+						"max_length"
+					]
+				}			
 			},
 			"tokenizer": {
 				"location_tokenizer": {
@@ -399,9 +407,13 @@ const indexSettings = `
 			"filter": {
                 "prefix_filter": { 
                     "type":     "edge_ngram",
-                    "min_gram": 1,
+                    "min_gram": 2,
                     "max_gram": 8
-                }
+				},
+				"max_length":{
+					"type": "truncate",
+					"length": 8
+				}
             }
         }
 	},
@@ -501,7 +513,7 @@ const indexSettings = `
 				"name": {
 					"type": "text",
 					"analyzer": "prefix",
-					"search_analyzer": "standard",
+					"search_analyzer": "name_search",
 					"fields": {
 						"keyword": {
 							"type": "keyword",

--- a/indexer_test.go
+++ b/indexer_test.go
@@ -75,6 +75,15 @@ func TestIndexing(t *testing.T) {
 	assertQuery(t, client, physicalName, elastic.NewMatchQuery("name", "JO"), []int64{5, 7})
 	assertQuery(t, client, physicalName, elastic.NewTermQuery("name.keyword", "JOHN DOE"), []int64{5})
 
+	// can search on both first and last name
+	boolQuery := elastic.NewBoolQuery().Must(
+		elastic.NewMatchQuery("name", "john"),
+		elastic.NewMatchQuery("name", "doe"))
+	assertQuery(t, client, physicalName, boolQuery, []int64{5})
+
+	// can search on a long name
+	assertQuery(t, client, physicalName, elastic.NewMatchQuery("name", "Ajodinabiff"), []int64{6})
+
 	assertQuery(t, client, physicalName, elastic.NewMatchQuery("language", "eng"), []int64{1})
 
 	// test contact, not indexed

--- a/testdb.sql
+++ b/testdb.sql
@@ -98,7 +98,7 @@ INSERT INTO contacts_contact(id, is_active, created_by_id, created_on, modified_
 '{ "05bca1cd-e322-4837-9595-86d0d85e5adb": {"text": "9", "decimal": 9 }, "e0eac267-463a-4c00-9732-cab62df07b16": { "text": "2018-04-06T18:37:59+00:00", "datetime": "2018-04-06T18:37:59+00:00"}}'),
 (5,  TRUE, -1, '2015-03-27 07:39:28.955051+00', -1, '2015-03-27 07:39:28.955051+00', 1, FALSE, 'John Doe', FALSE, NULL, '51762bba-01a2-4c4e-b5cd-b182d0405cd4', FALSE, 
 '{ "e0eac267-463a-4c00-9732-cab62df07b16": { "text": "2030-04-06T18:37:59+00:00", "datetime": "2030-04-06T18:37:59+00:00"}}'),
-(6,  TRUE, -1, '2015-10-30 19:42:27.001837+00', -1, '2015-10-30 19:42:27.001837+00', 2, FALSE, 'Ajodi Dane', FALSE, NULL, '3e814add-e614-41f7-8b5d-a07f670a698f', FALSE, 
+(6,  TRUE, -1, '2015-10-30 19:42:27.001837+00', -1, '2015-10-30 19:42:27.001837+00', 2, FALSE, 'Ajodinabiff Dane', FALSE, NULL, '3e814add-e614-41f7-8b5d-a07f670a698f', FALSE, 
 '{ "22d11697-edba-4186-b084-793e3b876379": { "text": "USA > Washington", "state": "USA > Washington"} }'),
 (7,  TRUE, -1, '2017-11-10 21:11:59.890662+00', -1, '2017-11-10 21:11:59.890662+00', 2, FALSE, 'Joanne Stone', FALSE, NULL, '7051dff0-0a27-49d7-af1f-4494239139e6', FALSE, 
 '{ "22d11697-edba-4186-b084-793e3b876379": { "text": "USA > Colorado", "state": "USA > Colorado"} }'),


### PR DESCRIPTION
fixes this case:
  https://sentry.io/nyaruka/textit/issues/529592597/

Which is caused by us creating ngrams for only the first 8 characters of each name. The search term however was going through the standard analyzer so wasn't matching due to that term being 9 characters. This PR changer our search analyzer to truncate the term at 8 chars. Added test as well.

Note this also changes the minimum name search length to be 2 chars.