### PR TITLE
Reduce shard count from 5 -> 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.0.27
+----------
+ * update ES shards to match current ES best-practice guidance
+
 v1.0.26
 ----------
  * move to go module, dont ignore any keywords
@@ -36,7 +40,6 @@ v1.0.18
 
 v1.0.17
 ----------
- 
  * change to number instead of decimal field
  * add example not exists query
 
@@ -59,7 +62,7 @@ v1.0.13
 v1.0.12
 ----------
  * add modified_on_mu for sorting / index creation
- * add prefix name for index building 
+ * add prefix name for index building
 
 v1.0.11
 ----------
@@ -107,4 +110,3 @@ v1.0.2
 v1.0.1
 ----------
  * Add changelog, move to fancy revving
-

--- a/README.md
+++ b/README.md
@@ -47,3 +47,11 @@ Environment variables:
                                 INDEXER_POLL - int
                              INDEXER_REBUILD - bool
 ```
+
+## Development
+
+To generate a local build for a linux amd64 architecture, use the following:
+
+```shell
+GOOS=linux GOARCH=amd64 go build github.com/nyaruka/rp-indexer/cmd/rp-indexer
+```

--- a/indexer.go
+++ b/indexer.go
@@ -408,9 +408,9 @@ const indexSettings = `
 {
 	"settings": {
 		"index": {
-			"number_of_shards": 5,
+			"number_of_shards": 2,
 			"number_of_replicas": 1,
-			"routing_partition_size": 3
+			"routing_partition_size": 1
 		},
 		"analysis": {
             "analyzer": {
@@ -433,7 +433,7 @@ const indexSettings = `
                     "tokenizer": "standard",
                     "filter": [
                         "lowercase",
-                        "prefix_filter" 
+                        "prefix_filter"
                     ]
 				},
 				"name_search": {
@@ -443,7 +443,7 @@ const indexSettings = `
 						"lowercase",
 						"max_length"
 					]
-				}			
+				}
 			},
 			"tokenizer": {
 				"location_tokenizer": {
@@ -465,7 +465,7 @@ const indexSettings = `
 				}
 			},
 			"filter": {
-                "prefix_filter": { 
+                "prefix_filter": {
                     "type":     "edge_ngram",
                     "min_gram": 2,
                     "max_gram": 8
@@ -564,7 +564,7 @@ const indexSettings = `
 				},
 				"modified_on_mu": {
 					"type": "long"
-				},		
+				},
 				"name": {
 					"type": "text",
 					"analyzer": "prefix",


### PR DESCRIPTION
Closes #17 

# Background

ES now defaults to a single shard.  5 was a poor default that allowed people to scale up to 5 nodes without thinking about it, but it penalized everyone who uses less.  This resolves that, and prepares for nodes maintaining multiple indexes a bit better (ie. a cluster doing more than just managing contacts search).

# General Performance
Just some reference for things we might want to consider in the future for additional performance improvements during a full reindex which can take a while: 
- https://www.elastic.co/guide/en/elasticsearch/reference/master/tune-for-indexing-speed.html (disable refresh for duration of reindex)
- https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html

# Technical Notes on the Why
## Shards and Replicas
- We have two nodes
- Each shard can be moved to a node, ie. three shards supports horizontal scaling of up to three nodes.
- A replica allows for redundancy of a given shard across X nodes.
- A replica is _in addition to_ the primary shard.
- This is the lowest common denominator (Figure 50) with two nodes and 1 or two shards) https://www.elastic.co/guide/en/elasticsearch/guide/current/overallocation.html
- This shows how replicas can improve redundancy across nodes: https://www.elastic.co/guide/en/elasticsearch/guide/current/replica-shards.html
- Replicas are primarily about failover, but can also serve read requests
- It is not more effective to have extra shards and replicas unless there are nodes backing them up.  Extra shards and replicas carry their own resource burdens.

## Routing
- `index.routing_partition_size`: https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html
- We only ever use one parameter (org id): https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-routing-field.html
- We don't need more than one route mapping
- Route mapping is for when you have multiple shards, and intentionally want some queries to go to one or another, perhaps for load leveling on uneven queries.

# Testing
- With only one shard, ES saw gateway timeouts (from the ALBs) during a full reindex, going back to 2 removed it.  This also seems faster than when there were 5 shards, which would indicate there was resource contention with 5, and severe under-usage when only on 1 shard.  Time to reindex our 4+mln contacts was ~1:45h with 5 shards, and ~1:20 with 2.
- Searches in RP work as expected post-index
- 

## Index Stats
Before
```
$ curl -XGET "https://ourdomain.us-west-2.es.amazonaws.com/_cat/indices/?v"
health status index               uuid                   pri rep docs.count docs.deleted store.size pri.store.size
green  open   contacts_2019_05_06 5M_s8esZRoC-V66RASU45Q   5   1  158607995     20979615     32.7gb         16.4gb
```

After
```
curl -XGET "https://ourdomain.us-west-2.es.amazonaws.com/_cat/indices/?v"
health status index               uuid                   pri rep docs.count docs.deleted store.size pri.store.size
green  open   contacts_2019_05_29 g4kc9MUjQpKLFziijFtFXQ   2   1  158617531         9362     35.5gb         17.8gb
```

File usage didn't drop probably because shards are splitting out the index into smaller pieces.  In any event, this more closely matches _our_ infrastructure, and would be much better for anyone with 1-2 nodes in their cluster.  Ideally this would be a runtime setting so people with more than 2 nodes can capture that performance, but the usage profile of this is really low-power from what I can tell.

## Indexer / Supervisor
Indexer continues to be happy in supervisor:

```
supervisor> tail indexer
tacts_2019_05_29 rate=293
time="2019-05-29T20:08:18Z" level=info msg="updated contact index" added=8 deleted=0 elapsed=57.547794ms index=contacts_2019_05_29 rate=243
time="2019-05-29T20:08:18Z" level=info msg="completed indexing" added=8 deleted=0 elapsed=65.606791ms index=contacts_2019_05_29
time="2019-05-29T20:08:24Z" level=info msg="indexing contacts newer than last modified" index=contacts_2019_05_29 last_modified="2019-05-29 20:08:18.765871 +0000 UTC"
time="2019-05-29T20:08:24Z" level=info msg="updated contact index" added=11 deleted=0 elapsed=80.460723ms index=contacts_2019_05_29 rate=223
time="2019-05-29T20:08:24Z" level=info msg="completed indexing" added=11 deleted=0 elapsed=88.817065ms index=contacts_2019_05_29
time="2019-05-29T20:08:29Z" level=info msg="indexing contacts newer than last modified" index=contacts_2019_05_29 last_modified="2019-05-29 20:08:23.971485 +0000 UTC"
time="2019-05-29T20:08:29Z" level=info msg="updated contact index" added=7 deleted=0 elapsed=43.817954ms index=contacts_2019_05_29 rate=365
time="2019-05-29T20:08:29Z" level=info msg="completed indexing" added=7 deleted=0 elapsed=52.789292ms index=contacts_2019_05_29
time="2019-05-29T20:08:34Z" level=info msg="indexing contacts newer than last modified" index=contacts_2019_05_29 last_modified="2019-05-29 20:08:28.958554 +0000 UTC"
time="2019-05-29T20:08:34Z" level=info msg="updated contact index" added=7 deleted=0 elapsed=44.02608ms index=contacts_2019_05_29 rate=317
time="2019-05-29T20:08:34Z" level=info msg="completed indexing" added=7 deleted=0 elapsed=59.720427ms index=contacts_2019_05_29
```

This was tested by building locally and scp'ing the binary.  Some dev notes added to help future noobs like myself.