### PR TITLE
Add `group_ids` field to replace `groups`

### DIFF
--- a/indexers/contacts.go
+++ b/indexers/contacts.go
@@ -146,6 +146,9 @@ SELECT org_id, id, modified_on, is_active, row_to_json(t) FROM (
 			) g
 		) AS groups,
 		(
+			SELECT array_to_json(array_agg(gc.contactgroup_id)) FROM contacts_contactgroup_contacts gc WHERE gc.contact_id = contacts_contact.id
+		) AS group_ids,
+		(
 			SELECT f.uuid FROM flows_flow f WHERE f.id = contacts_contact.current_flow_id
 		) AS flow,
 		current_flow_id AS flow_id,

--- a/indexers/contacts.settings.json
+++ b/indexers/contacts.settings.json
@@ -79,6 +79,23 @@
                 "required": true
             },
             "properties": {
+                "uuid": {
+                    "type": "keyword"
+                },
+                "name": {
+                    "type": "text",
+                    "analyzer": "prefix",
+                    "search_analyzer": "name_search",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword",
+                            "normalizer": "lowercase"
+                        }
+                    }
+                },
+                "status": {
+                    "type": "keyword"
+                },
                 "fields": {
                     "type": "nested",
                     "properties": {
@@ -144,10 +161,7 @@
                 "groups": {
                     "type": "keyword"
                 },
-                "uuid": {
-                    "type": "keyword"
-                },
-                "status": {
+                "group_ids": {
                     "type": "keyword"
                 },
                 "flow": {
@@ -177,17 +191,6 @@
                 },
                 "last_seen_on": {
                     "type": "date"
-                },
-                "name": {
-                    "type": "text",
-                    "analyzer": "prefix",
-                    "search_analyzer": "name_search",
-                    "fields": {
-                        "keyword": {
-                            "type": "keyword",
-                            "normalizer": "lowercase"
-                        }
-                    }
                 }
             }
         }

--- a/indexers/contacts_test.go
+++ b/indexers/contacts_test.go
@@ -183,6 +183,9 @@ var contactQueryTests = []struct {
 	{elastic.NewMatchQuery("groups", "4ea0f313-2f62-4e57-bdf0-232b5191dd57"), []int64{1}},
 	{elastic.NewMatchQuery("groups", "529bac39-550a-4d6f-817c-1833f3449007"), []int64{1, 2}},
 	{elastic.NewMatchQuery("groups", "4c016340-468d-4675-a974-15cb7a45a5ab"), []int64{}},
+	{elastic.NewMatchQuery("group_ids", 1), []int64{1}},
+	{elastic.NewMatchQuery("group_ids", 4), []int64{1, 2}},
+	{elastic.NewMatchQuery("group_ids", 2), []int64{}},
 }
 
 func TestContacts(t *testing.T) {


### PR DESCRIPTION
If we're going to have to map uuids to ids for flows.. might as well do it for groups too and make that easier to index