### PR TITLE
Drop deprecated `groups` and `flow` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v7.3.5
+----------
+ * Lower batch size to 100000 and log batch progress during rebuilds
+
 v7.3.4
 ----------
  * Add group_ids field to replace groups

--- a/indexers/contacts.go
+++ b/indexers/contacts.go
@@ -139,18 +139,8 @@ SELECT org_id, id, modified_on, is_active, row_to_json(t) FROM (
 			) AS f
 		) AS fields,
 		(
-			SELECT array_to_json(array_agg(g.uuid)) FROM (
-				SELECT contacts_contactgroup.uuid
-				FROM contacts_contactgroup_contacts, contacts_contactgroup
-				WHERE contact_id = contacts_contact.id AND contacts_contactgroup_contacts.contactgroup_id = contacts_contactgroup.id
-			) g
-		) AS groups,
-		(
 			SELECT array_to_json(array_agg(gc.contactgroup_id)) FROM contacts_contactgroup_contacts gc WHERE gc.contact_id = contacts_contact.id
 		) AS group_ids,
-		(
-			SELECT f.uuid FROM flows_flow f WHERE f.id = contacts_contact.current_flow_id
-		) AS flow,
 		current_flow_id AS flow_id,
 		(
 			SELECT array_to_json(array_agg(DISTINCT fr.flow_id)) FROM flows_flowrun fr WHERE fr.contact_id = contacts_contact.id

--- a/indexers/contacts.settings.json
+++ b/indexers/contacts.settings.json
@@ -158,13 +158,7 @@
                         }
                     }
                 },
-                "groups": {
-                    "type": "keyword"
-                },
                 "group_ids": {
-                    "type": "keyword"
-                },
-                "flow": {
                     "type": "keyword"
                 },
                 "flow_id": {

--- a/indexers/contacts_test.go
+++ b/indexers/contacts_test.go
@@ -28,8 +28,6 @@ var contactQueryTests = []struct {
 	{elastic.NewMatchQuery("tickets", 2), []int64{1}},
 	{elastic.NewMatchQuery("tickets", 1), []int64{2, 3}},
 	{elastic.NewRangeQuery("tickets").Gt(0), []int64{1, 2, 3}},
-	{elastic.NewMatchQuery("flow", "6d3cf1eb-546e-4fb8-a5ca-69187648fbf6"), []int64{2, 3}},
-	{elastic.NewMatchQuery("flow", "4eea8ff1-4fe2-4ce5-92a4-0870a499973a"), []int64{4}},
 	{elastic.NewMatchQuery("flow_id", 1), []int64{2, 3}},
 	{elastic.NewMatchQuery("flow_id", 2), []int64{4}},
 	{elastic.NewMatchQuery("flow_history_ids", 1), []int64{1, 2, 3}},
@@ -180,9 +178,6 @@ var contactQueryTests = []struct {
 		)),
 		[]int64{},
 	},
-	{elastic.NewMatchQuery("groups", "4ea0f313-2f62-4e57-bdf0-232b5191dd57"), []int64{1}},
-	{elastic.NewMatchQuery("groups", "529bac39-550a-4d6f-817c-1833f3449007"), []int64{1, 2}},
-	{elastic.NewMatchQuery("groups", "4c016340-468d-4675-a974-15cb7a45a5ab"), []int64{}},
 	{elastic.NewMatchQuery("group_ids", 1), []int64{1}},
 	{elastic.NewMatchQuery("group_ids", 4), []int64{1, 2}},
 	{elastic.NewMatchQuery("group_ids", 2), []int64{}},
@@ -235,7 +230,7 @@ func TestContacts(t *testing.T) {
 	assertQuery(t, es, elastic.NewMatchQuery("name", "john"), []int64{2})
 
 	// 3 is no longer in our group
-	assertQuery(t, es, elastic.NewMatchQuery("groups", "529bac39-550a-4d6f-817c-1833f3449007"), []int64{1})
+	assertQuery(t, es, elastic.NewMatchQuery("group_ids", 4), []int64{1})
 
 	// change John's name to Eric..
 	_, err = db.Exec(`


### PR DESCRIPTION
Which are now replaced by `group_ids` and `flow_id`