### PR TITLE
Remove `_type` field from index and delete commands

### DIFF
--- a/indexers/base.go
+++ b/indexers/base.go
@@ -16,10 +16,10 @@ import (
 )
 
 // indexes a document
-const indexCommand = `{ "index": { "_id": %d, "_type": "_doc", "version": %d, "version_type": "external", "routing": %d} }`
+const indexCommand = `{ "index": { "_id": %d, "version": %d, "version_type": "external", "routing": %d} }`
 
 // deletes a document
-const deleteCommand = `{ "delete" : { "_id": %d, "_type": "_doc", "version": %d, "version_type": "external", "routing": %d} }`
+const deleteCommand = `{ "delete" : { "_id": %d, "version": %d, "version_type": "external", "routing": %d} }`
 
 type Stats struct {
 	Indexed int64         // total number of documents indexed


### PR DESCRIPTION
@ericnewcomer @norkans7 I've tested locally running this (with https://github.com/nyaruka/rp-indexer/pull/70) on an existing index created with types and there doesn't seem to be any problem.

Removal of types within indexes (we don't use multi-type indexes) is the big breaking change between ES7/OS1 and ES8/OS2.